### PR TITLE
change to rust docker container instead of generic alpine

### DIFF
--- a/dockerfiles/rs-Dockerfile
+++ b/dockerfiles/rs-Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.13.2
-
-RUN apk add rust
+FROM rust:1.50.0-alpine3.12 
 
 ARG MESSAGE_ID
 


### PR DESCRIPTION
@AlexBethel I changed the dockerfile to use a Rust container instead of manually adding Rust to an Alpine container (same practice for Python and Go). Please confirm the compilation will still work.